### PR TITLE
chore(*): update Cargo.lock/package-lock.json files

### DIFF
--- a/aggregate-pattern/aggregates-service/Cargo.lock
+++ b/aggregate-pattern/aggregates-service/Cargo.lock
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.2.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05d0c09c0935fbb586d0a76e0f14b26b23f421c5e11b81d7200d22c4ead1211"
+checksum = "ed97f54a15f2d8b1fa15e436d88bacb95a5b379a3e0f8fbd8042eb8696ca048a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aggregate-pattern/customers-service/package-lock.json
+++ b/aggregate-pattern/customers-service/package-lock.json
@@ -1526,6 +1526,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",

--- a/http-crud-js-pg/package-lock.json
+++ b/http-crud-js-pg/package-lock.json
@@ -1337,6 +1337,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",

--- a/http-crud-js-sqlite/package-lock.json
+++ b/http-crud-js-sqlite/package-lock.json
@@ -1337,6 +1337,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",

--- a/pub-sub-polyglot/http-publisher-js/package-lock.json
+++ b/pub-sub-polyglot/http-publisher-js/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "http-publisher-js",
+  "name": "http-publisher",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "http-publisher-js",
+      "name": "http-publisher",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/pub-sub-polyglot/mass-publisher/Cargo.lock
+++ b/pub-sub-polyglot/mass-publisher/Cargo.lock
@@ -153,7 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
-name = "mass-publisher-rust"
+name = "mass-publisher"
 version = "0.1.0"
 dependencies = [
  "anyhow",


### PR DESCRIPTION
Another quick chore PR moving through the applications and rerunning spin build to ensure the appropriate lock files are up-to-date.
