### PR TITLE
fix(ci.yaml): pin go version for tinygo compat

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          # choosing one of the go projects to determine version
+          go-version-file: 'http-crud-go-sqlite/go.mod'
       - name: Install TinyGo
         uses: rajatjindal/setup-actions/tinygo@v0.0.1
         with:


### PR DESCRIPTION
(attempted) fix for recent CI failure as seen here: https://github.com/fermyon/enterprise-architectures-and-patterns/actions/runs/11260138587/job/31902122595?pr=20